### PR TITLE
add various boss remain shuffles

### DIFF
--- a/worlds/mm_recomp/EXAMPLE_YAML.yaml
+++ b/worlds/mm_recomp/EXAMPLE_YAML.yaml
@@ -97,6 +97,16 @@ Majora's Mask Recompiled:
     containers: 50
     pieces: 0
 
+  shuffle_boss_remains:
+    # Choose whether to shuffle the Boss Remains received after beating a boss at the end of a dungeon.
+    #
+    # vanilla: Boss Remains are placed in their vanilla locations.
+    # anything: Any item can be given by any of the Boss Remains, and Boss Remains can be found anywhere in any world.
+    # bosses: Boss Remains are shuffled amongst themselves as the rewards for defeating bosses.
+    vanila: 0
+    anywhere: 50
+    bosses: 0
+
   shuffle_swamphouse_reward:
     # Choose whether to shuffle the Mask of Truth given at the end of the Southern Swamphouse.
     'false': 50

--- a/worlds/mm_recomp/Items.py
+++ b/worlds/mm_recomp/Items.py
@@ -386,19 +386,23 @@ item_data_table: Dict[str, MMRItemData] = {
     ),
     "Odolwa's Remains": MMRItemData(
         code=0x3469420000055,
-        type=ItemClassification.progression
+        type=ItemClassification.progression,
+        can_create=lambda options: options.shuffle_boss_remains.value == 1
     ),
     "Goht's Remains": MMRItemData(
         code=0x3469420000056,
-        type=ItemClassification.progression
+        type=ItemClassification.progression,
+        can_create=lambda options: options.shuffle_boss_remains.value == 1
     ),
     "Gyorg's Remains": MMRItemData(
         code=0x3469420000057,
-        type=ItemClassification.progression
+        type=ItemClassification.progression,
+        can_create=lambda options: options.shuffle_boss_remains.value == 1
     ),
     "Twinmold's Remains": MMRItemData(
         code=0x3469420000058,
-        type=ItemClassification.progression
+        type=ItemClassification.progression,
+        can_create=lambda options: options.shuffle_boss_remains.value == 1
     ),
     "Progressive Bomb Bag": MMRItemData(
         code=0x346942000001B,

--- a/worlds/mm_recomp/Options.py
+++ b/worlds/mm_recomp/Options.py
@@ -48,6 +48,19 @@ class StartingHeartsAreContainersOrPieces(Choice):
     default = 0
 
 
+class ShuffleBossRemains(Choice):
+    """Choose whether to shuffle the Boss Remains received after beating a boss at the end of a dungeon.
+    
+    vanilla: Boss Remains are placed in their vanilla locations.
+    anything: Any item can be given by any of the Boss Remains, and Boss Remains can be found anywhere in any world.
+    bosses: Boss Remains are shuffled amongst themselves as the rewards for defeating bosses."""
+    display_name = "Shuffle Boss Remains"
+    option_vanila = 0
+    option_anywhere = 1
+    option_bosses = 2
+    default = 1
+
+
 class ShuffleSwamphouseReward(Toggle):
     """Choose whether to shuffle the Mask of Truth given at the end of the Southern Swamphouse."""
     display_name = "Shuffle Swamphouse Reward"
@@ -105,6 +118,7 @@ class MMROptions(PerGameCommonOptions):
     shieldless: Shieldless
     starting_hearts: StartingHeartQuarters
     starting_hearts_are_containers_or_pieces: StartingHeartsAreContainersOrPieces
+    shuffle_boss_remains: ShuffleBossRemains
     shuffle_swamphouse_reward: ShuffleSwamphouseReward
     skullsanity: Skullsanity
     shuffle_great_fairy_rewards: ShuffleGreatFairyRewards

--- a/worlds/mm_recomp/__init__.py
+++ b/worlds/mm_recomp/__init__.py
@@ -102,6 +102,20 @@ class MMRWorld(World):
             locked_item = self.create_item(location_data_table[location_name].locked_item)
             mw.get_location(location_name, player).place_locked_item(locked_item)
 
+        if self.options.shuffle_boss_remains.value == 0:
+            mw.get_location("Woodfall Temple Odolwa's Remains", player).place_locked_item(self.create_item("Odolwa's Remains"))
+            mw.get_location("Snowhead Temple Goht's Remains", player).place_locked_item(self.create_item("Goht's Remains"))
+            mw.get_location("Great Bay Temple Gyorg's Remains", player).place_locked_item(self.create_item("Gyorg's Remains"))
+            mw.get_location("Stone Tower Temple Inverted Twinmold's Remains", player).place_locked_item(self.create_item("Twinmold's Remains"))
+        
+        if self.options.shuffle_boss_remains.value == 2:
+            remains_list = ["Odolwa's Remains", "Goht's Remains", "Gyorg's Remains", "Twinmold's Remains"]
+            
+            mw.get_location("Woodfall Temple Odolwa's Remains", player).place_locked_item(self.create_item(remains_list.pop(self.random.randint(0, 3))))
+            mw.get_location("Snowhead Temple Goht's Remains", player).place_locked_item(self.create_item(remains_list.pop(self.random.randint(0, 2))))
+            mw.get_location("Great Bay Temple Gyorg's Remains", player).place_locked_item(self.create_item(remains_list.pop(self.random.randint(0, 1))))
+            mw.get_location("Stone Tower Temple Inverted Twinmold's Remains", player).place_locked_item(self.create_item(remains_list[0]))
+
         if not self.options.shuffle_swamphouse_reward.value:
             mw.get_location("Swamp Spider House Reward", player).place_locked_item(self.create_item("Mask of Truth"))
 


### PR DESCRIPTION
Adds an option to limit where boss remains can shuffle to. 

`anywhere` is the current behavior, shuffling boss remains to be anywhere in any world.
`vanilla` will place the boss remains in their vanilla locations.
`bosses` will shuffle the boss remains between themselves and place them at boss remain locations.