### PR TITLE
adjust default options

### DIFF
--- a/worlds/mm_recomp/EXAMPLE_YAML.yaml
+++ b/worlds/mm_recomp/EXAMPLE_YAML.yaml
@@ -80,6 +80,11 @@ Majora's Mask Recompiled:
     'false': 50
     'true': 0
 
+  start_with_soaring:
+    # Start the game with Song of Soaring.
+    'false': 0
+    'true': 50
+
   starting_hearts:
     # The number of heart quarters Link starts with.
     # If less than 12, extra heart items will be shuffled into the pool to accommodate.
@@ -103,8 +108,8 @@ Majora's Mask Recompiled:
     # vanilla: Boss Remains are placed in their vanilla locations.
     # anything: Any item can be given by any of the Boss Remains, and Boss Remains can be found anywhere in any world.
     # bosses: Boss Remains are shuffled amongst themselves as the rewards for defeating bosses.
-    vanila: 0
-    anywhere: 50
+    vanila: 50
+    anywhere: 0
     bosses: 0
 
   shuffle_swamphouse_reward:
@@ -134,13 +139,13 @@ Majora's Mask Recompiled:
 
   start_with_consumables:
     # Choose whether to start with basic consumables (99 rupees, 10 deku sticks, 20 deku nuts).
-    'false': 50
-    'true': 0
+    'false': 0
+    'true': 50
 
   permanent_chateau_romani:
     # Choose whether the Chateau Romani stays even after a reset.
-    'false': 50
-    'true': 0
+    'false': 0
+    'true': 50
 
   reset_with_inverted_time:
     # Choose whether time starts out inverted at Day 1, even after a reset.
@@ -149,8 +154,8 @@ Majora's Mask Recompiled:
 
   receive_filled_wallets:
     # Choose whether you receive wallets pre-filled (not including the starting wallet).
-    'false': 50
-    'true': 0
+    'false': 0
+    'true': 50
 
   death_link:
     # When you die, everyone who enabled death link dies. Of course, the reverse is true too.

--- a/worlds/mm_recomp/Options.py
+++ b/worlds/mm_recomp/Options.py
@@ -31,6 +31,11 @@ class Shieldless(Toggle):
     display_name = "Shieldless"
 
 
+class StartWithSoaring(DefaultOnToggle):
+    """Start the game with Song of Soaring."""
+    display_name = "Start With Soaring"
+
+
 class StartingHeartQuarters(Range):
     """The number of heart quarters Link starts with.
     If less than 12, extra heart items will be shuffled into the pool to accommodate."""
@@ -58,7 +63,7 @@ class ShuffleBossRemains(Choice):
     option_vanila = 0
     option_anywhere = 1
     option_bosses = 2
-    default = 1
+    default = 0
 
 
 class ShuffleSwamphouseReward(Toggle):
@@ -89,12 +94,12 @@ class Fairysanity(Toggle):
     display_name = "Fairysanity"
 
 
-class StartWithConsumables(Toggle):
+class StartWithConsumables(DefaultOnToggle):
     """Choose whether to start with basic consumables (99 rupees, 10 deku sticks, 20 deku nuts)."""
     display_name = "Start With Consumables"
 
 
-class PermanentChateauRomani(Toggle):
+class PermanentChateauRomani(DefaultOnToggle):
     """Choose whether the Chateau Romani stays even after a reset."""
     display_name = "Permanent Chateau Romani"
 
@@ -104,7 +109,7 @@ class ResetWithInvertedTime(Toggle):
     display_name = "Reset With Inverted Time"
 
 
-class ReceiveFilledWallets(Toggle):
+class ReceiveFilledWallets(DefaultOnToggle):
     """Choose whether you receive wallets pre-filled (not including the starting wallet)."""
     display_name = "Receive Filled Wallets"
 
@@ -122,6 +127,7 @@ class MMROptions(PerGameCommonOptions):
     camc: CAMC
     swordless: Swordless
     shieldless: Shieldless
+    start_with_soaring: StartWithSoaring
     starting_hearts: StartingHeartQuarters
     starting_hearts_are_containers_or_pieces: StartingHeartsAreContainersOrPieces
     shuffle_boss_remains: ShuffleBossRemains

--- a/worlds/mm_recomp/__init__.py
+++ b/worlds/mm_recomp/__init__.py
@@ -65,6 +65,9 @@ class MMRWorld(World):
         if self.options.shieldless.value:
             mw.itempool.append(self.create_item("Progressive Shield"))
 
+        if self.options.start_with_soaring.value:
+            mw.push_precollected(self.create_item("Song of Soaring"))
+
         shp = self.options.starting_hearts.value
         if self.options.starting_hearts_are_containers_or_pieces.value == 0:
             for i in range(0, int((12 - shp)/4)):


### PR DESCRIPTION
Add starting with Song of Soaring as a default YAML option.

Adjust options for:
- Boss Remains: set to vanilla locations by default
- Consumables: enabled
- Chateau: enabled
- Fill wallets: enabled

I didn't change this here, but I would say to rename `reset_with_inverted_time` to `start_with_inverted_time` everywhere applicable.