### PR TITLE
add options for damage/death + sanities

### DIFF
--- a/worlds/mm_recomp/EXAMPLE_YAML.yaml
+++ b/worlds/mm_recomp/EXAMPLE_YAML.yaml
@@ -139,7 +139,7 @@ Majora's Mask Recompiled:
     #
     # vanilla: Shop items are not shuffled.
     # enabled: Every item in shops are shuffled, with alternate shops sharing the same items.
-    # advanced: Every single item in shops are shuffled, including the alternate Night Trading Post and Spring Goron Shop.
+    # advanced: Every single item in shops are shuffled, including the alternate Night Trading Post and Spring Goron Shop. Also adds an extra Heart Piece to Spring Goron Village.
     vanilla: 50
     enabled: 0
     advanced: 0
@@ -174,8 +174,8 @@ Majora's Mask Recompiled:
     'false': 0
     'true': 50
 
-  reset_with_inverted_time:
-    # Choose whether time starts out inverted at Day 1, even after a reset.
+  start_with_inverted_time:
+    # Choose whether time starts out inverted at Day 1.
     'false': 50
     'true': 0
 

--- a/worlds/mm_recomp/EXAMPLE_YAML.yaml
+++ b/worlds/mm_recomp/EXAMPLE_YAML.yaml
@@ -154,11 +154,21 @@ Majora's Mask Recompiled:
 
   damage_multiplier:
     # Adjust the amount of damage taken.
-    'half': 0
-    'normal': 50
-    'double': 0
-    'quad': 0
-    'ohko': 0
+    half: 0
+    normal: 50
+    double: 0
+    quad: 0
+    ohko: 0
+  
+  death_behavior:
+    # Change what happens when you die.
+    #
+    # vanilla: The normal death cutscene plays when you die.
+    # fast: The death cutscene is massively sped up.
+    # moon_crash: Triggers a moon crash and restarts the current cycle.
+    vanilla: 50
+    fast: 0
+    moon_crash: 0
 
   link_tunic_color:
     [30, 105, 27]

--- a/worlds/mm_recomp/EXAMPLE_YAML.yaml
+++ b/worlds/mm_recomp/EXAMPLE_YAML.yaml
@@ -154,6 +154,7 @@ Majora's Mask Recompiled:
 
   damage_multiplier:
     # Adjust the amount of damage taken.
+    'half': 0
     'normal': 50
     'double': 0
     'quad': 0

--- a/worlds/mm_recomp/EXAMPLE_YAML.yaml
+++ b/worlds/mm_recomp/EXAMPLE_YAML.yaml
@@ -133,6 +133,27 @@ Majora's Mask Recompiled:
     anything: 0
     ignore: 0
 
+  shopsanity:
+    # Choose whether shops and their items are shuffled into the pool.
+    # This includes Trading Post, Bomb Shop, Goron Shop, and Zora Shop, along with the Gorman Ranch and Milk Bar purchases.
+    #
+    # vanilla: Shop items are not shuffled.
+    # enabled: Every item in shops are shuffled, with alternate shops sharing the same items.
+    # advanced: Every single item in shops are shuffled, including the alternate Night Trading Post and Spring Goron Shop.
+    vanilla: 50
+    enabled: 0
+    advanced: 0
+
+  scrubsanity:
+    # Choose whether to shuffle Business Scrub purchases.
+    'false': 50
+    'true': 0
+
+  cowsanity:
+    # Choose whether to shuffle Cows.
+    'false': 50
+    'true': 0
+
   shuffle_great_fairy_rewards:
     # Choose whether to shuffle Great Fairy rewards.
     'false': 50

--- a/worlds/mm_recomp/EXAMPLE_YAML.yaml
+++ b/worlds/mm_recomp/EXAMPLE_YAML.yaml
@@ -152,6 +152,13 @@ Majora's Mask Recompiled:
     'false': 50
     'true': 0
 
+  damage_multiplier:
+    # Adjust the amount of damage taken.
+    'normal': 50
+    'double': 0
+    'quad': 0
+    'ohko': 0
+
   link_tunic_color:
     [30, 105, 27]
 

--- a/worlds/mm_recomp/Items.py
+++ b/worlds/mm_recomp/Items.py
@@ -483,8 +483,33 @@ item_data_table: Dict[str, MMRItemData] = {
     "Red Rupee": MMRItemData(
         code=0x3469420000004,
         type=ItemClassification.filler,
-        num_exist=37 # lol
+        num_exist=34
         # ~ num_exist=29
+    ),
+    # this is horrible, please find something better
+    "Deku Nuts (10)": MMRItemData(
+        code=0x346942000002A,
+        type=ItemClassification.filler,
+        num_exist=4,
+        can_create=lambda options: options.scrubsanity.value != 0
+    ),
+    "Deku Nuts (1)": MMRItemData(
+        code=0x3469420000028,
+        type=ItemClassification.filler,
+        num_exist=21,
+        can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Gold Rupee": MMRItemData(
+        code=0x3469420000007,
+        type=ItemClassification.filler,
+        num_exist=12,
+        can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Milk": MMRItemData(
+        code=0x3469420000092,
+        type=ItemClassification.filler,
+        num_exist=8,
+        can_create=lambda options: options.cowsanity.value != 0
     ),
     "Purple Rupee": MMRItemData(
         code=0x3469420000005,

--- a/worlds/mm_recomp/Items.py
+++ b/worlds/mm_recomp/Items.py
@@ -505,8 +505,8 @@ item_data_table: Dict[str, MMRItemData] = {
         num_exist=12,
         can_create=lambda options: options.shopsanity.value == 2
     ),
-    "Milk": MMRItemData(
-        code=0x3469420000092,
+    "Bombs (10)": MMRItemData(
+        code=0x3469420000016,
         type=ItemClassification.filler,
         num_exist=8,
         can_create=lambda options: options.cowsanity.value != 0

--- a/worlds/mm_recomp/Locations.py
+++ b/worlds/mm_recomp/Locations.py
@@ -93,6 +93,114 @@ location_data_table: Dict[str, MMRLocationData] = {
         region="Clock Town",
         address=0x3469420000050
     ),
+    "Clock Town Trading Post Shop Item 1": MMRLocationData(
+        region="Clock Town",
+        address=0x346942009000A,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Trading Post Shop Item 2": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090005,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Trading Post Shop Item 3": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090006,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Trading Post Shop Item 4": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090003,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Trading Post Shop Item 5": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090007,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Trading Post Shop Item 6": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090008,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Trading Post Shop Item 7": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090009,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Trading Post Shop Item 8": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090004,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Trading Post Shop (Night) Item 1": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090012,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Clock Town Trading Post Shop (Night) Item 2": MMRLocationData(
+        region="Clock Town",
+        address=0x346942009000E,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Clock Town Trading Post Shop (Night) Item 3": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090011,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Clock Town Trading Post Shop (Night) Item 4": MMRLocationData(
+        region="Clock Town",
+        address=0x346942009000B,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Clock Town Trading Post Shop (Night) Item 5": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090010,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Clock Town Trading Post Shop (Night) Item 6": MMRLocationData(
+        region="Clock Town",
+        address=0x346942009000C,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Clock Town Trading Post Shop (Night) Item 7": MMRLocationData(
+        region="Clock Town",
+        address=0x346942009000F,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Clock Town Trading Post Shop (Night) Item 8": MMRLocationData(
+        region="Clock Town",
+        address=0x346942009000D,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Clock Town Bomb Shop Item 1": MMRLocationData(
+        region="Clock Town",
+        address=0x346942009001A,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Bomb Shop Item 2": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090019,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Clock Town Bomb Shop Item 3": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090017,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Bomb Bag Purchase": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090018,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Curiosity Shop Night 3 (Stop Thief)": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090013
+    ),
+    "Curiosity Shop Night 2 & 3 Thief Item": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420090015
+    ),
     "Laundry Pool Stray Fairy (Clock Town)": MMRLocationData(
         region="Clock Town",
         address=0x346942001007F
@@ -273,6 +381,14 @@ location_data_table: Dict[str, MMRLocationData] = {
         region="Clock Town",
         address=0x346942000006F
     ),
+    "East Clock Town Milk Bar Milk Purchase": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420026392
+    ),
+    "East Clock Town Milk Bar Chateau Romani Purchase": MMRLocationData(
+        region="Clock Town",
+        address=0x3469420000091
+    ),
     "Tingle Clock Town Map Purchase": MMRLocationData(
         region="Clock Town",
         address=0x34694200000B4
@@ -319,11 +435,13 @@ location_data_table: Dict[str, MMRLocationData] = {
     ),
     "Termina Log Bombable Grotto Left Cow": MMRLocationData(
         region="Termina Field",
-        address=0x3469420BEEF14
+        address=0x3469420BEEF14,
+        # can_create=lambda options: options.cowsanity.value
     ),
     "Termina Log Bombable Grotto Right Cow": MMRLocationData(
         region="Termina Field",
-        address=0x3469420BEEF13
+        address=0x3469420BEEF13,
+        # can_create=lambda options: options.cowsanity.value
     ),
     "Termina Dodongo Grotto Chest": MMRLocationData(
         region="Termina Field",
@@ -368,6 +486,11 @@ location_data_table: Dict[str, MMRLocationData] = {
     "Southern Swamp Deku Trade": MMRLocationData(
         region="Southern Swamp",
         address=0x3469420000098
+    ),    
+    "Southern Swamp Deku Scrub Purchase Beans": MMRLocationData(
+        region="Southern Swamp",
+        address=0x3469420090135,
+        # can_create=lambda options: options.scrubsanity.value
     ),
     "Southern Swamp Deku Trade Freestanding HP": MMRLocationData(
         region="Southern Swamp",
@@ -384,6 +507,21 @@ location_data_table: Dict[str, MMRLocationData] = {
     "Southern Swamp Tour Witch Gift": MMRLocationData(
         region="Southern Swamp",
         address=0x3469420000043
+    ),
+    "Southern Swamp Witch Shop Item 1": MMRLocationData(
+        region="Southern Swamp",
+        address=0x3469420090002,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Southern Swamp Witch Shop Item 2": MMRLocationData(
+        region="Southern Swamp",
+        address=0x3469420090001,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Southern Swamp Witch Shop Item 3": MMRLocationData(
+        region="Southern Swamp",
+        address=0x3469420090000,
+        # can_create=lambda options: options.shopsanity.value != 0
     ),
     "Swamp Spider House First Room Pot Near Entrance Token": MMRLocationData(
         region="Swamp Spider House",
@@ -719,6 +857,41 @@ location_data_table: Dict[str, MMRLocationData] = {
         region="Goron Village",
         address=0x3469420060701
     ),
+    "Goron Village Shop Item 1": MMRLocationData(
+        region="Goron Village",
+        address=0x346942009001E,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Goron Village Shop Item 2": MMRLocationData(
+        region="Goron Village",
+        address=0x346942009001F,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Goron Village Shop Item 3": MMRLocationData(
+        region="Goron Village",
+        address=0x3469420090020,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Goron Village Shop (Spring) Item 1": MMRLocationData(
+        region="Goron Village",
+        address=0x3469420090021,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Goron Village Shop (Spring) Item 2": MMRLocationData(
+        region="Goron Village",
+        address=0x3469420090022,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),
+    "Goron Village Shop (Spring) Item 3": MMRLocationData(
+        region="Goron Village",
+        address=0x3469420090023,
+        # can_create=lambda options: options.shopsanity.value == 2
+    ),    
+    "Goron Village Deku Scrub Purchase Bomb Bag": MMRLocationData(
+        region="Goron Village",
+        address=0x346942009011D,
+        # can_create=lambda options: options.scrubsanity.value
+    ),
     "Goron Village Deku Trade": MMRLocationData(
         region="Goron Village",
         address=0x3469420000099
@@ -726,6 +899,11 @@ location_data_table: Dict[str, MMRLocationData] = {
     "Goron Village Deku Trade Freestanding HP": MMRLocationData(
         region="Goron Village",
         address=0x3469420054D1E
+    ),
+    "Goron Village Deku Trade Freestanding HP (Spring)": MMRLocationData(
+        region="Goron Village",
+        address=0x346942005481E,
+        # can_create=lambda options: options.shopsanity.value == 2
     ),
     "Path to Snowhead Grotto Chest": MMRLocationData(
         region="Path to Snowhead",
@@ -839,17 +1017,24 @@ location_data_table: Dict[str, MMRLocationData] = {
         region="Gorman Brothers Track",
         address=0x3469420000081
     ),
+    "Milk Road Gorman Ranch Purchase": MMRLocationData(
+        region="Gorman Brothers Track",
+        address=0x3469420006792
+    ),
     "Romani Ranch Barn Free Cow": MMRLocationData(
         region="Romani Ranch",
-        address=0x3469420BEEF10
+        address=0x3469420BEEF10,
+        # can_create=lambda options: options.cowsanity.value
     ),
     "Romani Ranch Barn Stables Front Cow": MMRLocationData(
         region="Romani Ranch",
-        address=0x3469420BEEF11
+        address=0x3469420BEEF11,
+        # can_create=lambda options: options.cowsanity.value
     ),
     "Romani Ranch Barn Stables Back Cow": MMRLocationData(
         region="Romani Ranch",
-        address=0x3469420BEEF12
+        address=0x3469420BEEF12,
+        # can_create=lambda options: options.cowsanity.value
     ),
     "Romani Ranch Grog": MMRLocationData(
         region="Romani Ranch",
@@ -877,11 +1062,13 @@ location_data_table: Dict[str, MMRLocationData] = {
     ),
     "Great Bay Ledge Grotto Left Cow": MMRLocationData(
         region="Great Bay",
-        address=0x3469420BEEF16
+        address=0x3469420BEEF16,
+        # can_create=lambda options: options.cowsanity.value
     ),
     "Great Bay Ledge Grotto Right Cow": MMRLocationData(
         region="Great Bay",
-        address=0x3469420BEEF15
+        address=0x3469420BEEF15,
+        # can_create=lambda options: options.cowsanity.value
     ),
     "Great Bay Scarecrow Ledge HP": MMRLocationData(
         region="Great Bay",
@@ -910,6 +1097,26 @@ location_data_table: Dict[str, MMRLocationData] = {
     "Great Bay Great Fairy Reward": MMRLocationData(
         region="Zora Cape",
         address=0x3469420030003
+    ),
+    "Zora Hall Shop 1": MMRLocationData(
+        region="Zora Hall",
+        address=0x346942009001B,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Zora Hall Shop 2": MMRLocationData(
+        region="Zora Hall",
+        address=0x346942009001C,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Zora Hall Shop 3": MMRLocationData(
+        region="Zora Hall",
+        address=0x346942009001D,
+        # can_create=lambda options: options.shopsanity.value != 0
+    ),
+    "Zora Hall Deku Scrub Purchase Green Potion": MMRLocationData(
+        region="Zora Hall",
+        address=0x346942009015C,
+        # can_create=lambda options: options.scrubsanity.value
     ),
     "Zora Hall Goron Scrub Trade": MMRLocationData(
         region="Zora Hall",
@@ -1281,6 +1488,11 @@ location_data_table: Dict[str, MMRLocationData] = {
         region="Secret Shrine",
         address=0x3469420060714
     ),
+    "Ikana Canyon Deku Scrub Purchase Blue Potion": MMRLocationData(
+        region="Ikana Canyon",
+        address=0x346942009015D,
+        # can_create=lambda options: options.scrubsanity.value
+    ),
     "Ikana Canyon Zora Trade Freestanding HP": MMRLocationData(
         region="Ikana Canyon",
         address=0x346942005131E
@@ -1307,7 +1519,8 @@ location_data_table: Dict[str, MMRLocationData] = {
     ),
     "Ikana Well Cow": MMRLocationData(
         region="Beneath the Well",
-        address=0x3469420BEEF17
+        address=0x3469420BEEF17,
+        # can_create=lambda options: options.cowsanity.value
     ),
     "Ikana Castle Pillar Freestanding HP": MMRLocationData(
         region="Ikana Castle",

--- a/worlds/mm_recomp/Options.py
+++ b/worlds/mm_recomp/Options.py
@@ -135,7 +135,7 @@ class PermanentChateauRomani(DefaultOnToggle):
     display_name = "Permanent Chateau Romani"
 
 
-class ResetWithInvertedTime(Toggle):
+class StartWithInvertedTime(Toggle):
     """Choose whether time starts out inverted at Day 1, even after a reset."""
     display_name = "Reset With Inverted Time"
 
@@ -195,7 +195,7 @@ class MMROptions(PerGameCommonOptions):
     fairysanity: Fairysanity
     start_with_consumables: StartWithConsumables
     permanent_chateau_romani: PermanentChateauRomani
-    reset_with_inverted_time: ResetWithInvertedTime
+    start_with_inverted_time: StartWithInvertedTime
     receive_filled_wallets: ReceiveFilledWallets
     damage_multiplier: DamageMultiplier
     death_behavior: DeathBehavior

--- a/worlds/mm_recomp/Options.py
+++ b/worlds/mm_recomp/Options.py
@@ -112,11 +112,12 @@ class ReceiveFilledWallets(Toggle):
 class DamageMultiplier(Choice):
     """Adjust the amount of damage taken."""
     display_name = "Damage Multiplier"
-    option_normal = 0
-    option_double = 1
-    option_quad = 2
-    option_ohko = 3
-    default = 0
+    option_half = 0
+    option_normal = 1
+    option_double = 2
+    option_quad = 3
+    option_ohko = 4
+    default = 1
 
 
 class LinkTunicColor(OptionList):

--- a/worlds/mm_recomp/Options.py
+++ b/worlds/mm_recomp/Options.py
@@ -92,6 +92,29 @@ class Skullsanity(Choice):
     default = 0
 
 
+class Shopsanity(Choice):
+    """Choose whether shops and their items are shuffled into the pool.
+    This includes Trading Post, Bomb Shop, Goron Shop, and Zora Shop, along with the Gorman Ranch and Milk Bar purchases.
+    
+    vanilla: Shop items are not shuffled.
+    enabled: Every item in shops are shuffled, with alternate shops sharing the same items.
+    advanced: Every single item in shops are shuffled, including the alternate Night Trading Post and Spring Goron Shop. Also adds an extra Heart Piece to Spring Goron Village."""
+    display_name = "Shopsanity"
+    option_vanilla = 0
+    option_enabled = 1
+    option_advanced = 2
+    default = 0
+
+
+class Scrubsanity(Toggle):
+    """Choose whether to shuffle Business Scrub purchases."""
+    display_name = "Shuffle Business Scrub Purchases"
+
+class Cowsanity(Toggle):
+    """Choose whether to shuffle Cows."""
+    display_name = "Shuffle Cows"
+
+
 class ShuffleGreatFairyRewards(Toggle):
     """Choose whether to shuffle Great Fairy rewards."""
     display_name = "Shuffle Great Fairy Rewards"
@@ -165,6 +188,9 @@ class MMROptions(PerGameCommonOptions):
     shuffle_boss_remains: ShuffleBossRemains
     shuffle_swamphouse_reward: ShuffleSwamphouseReward
     skullsanity: Skullsanity
+    shopsanity: Shopsanity
+    scrubsanity: Scrubsanity
+    cowsanity: Cowsanity
     shuffle_great_fairy_rewards: ShuffleGreatFairyRewards
     fairysanity: Fairysanity
     start_with_consumables: StartWithConsumables

--- a/worlds/mm_recomp/Options.py
+++ b/worlds/mm_recomp/Options.py
@@ -109,6 +109,16 @@ class ReceiveFilledWallets(Toggle):
     display_name = "Receive Filled Wallets"
 
 
+class DamageMultiplier(Choice):
+    """Adjust the amount of damage taken."""
+    display_name = "Damage Multiplier"
+    option_normal = 0
+    option_double = 1
+    option_quad = 2
+    option_ohko = 3
+    default = 0
+
+
 class LinkTunicColor(OptionList):
     """Choose a color for Link's tunic."""
     display_name = "Link Tunic Color"
@@ -133,5 +143,6 @@ class MMROptions(PerGameCommonOptions):
     permanent_chateau_romani: PermanentChateauRomani
     reset_with_inverted_time: ResetWithInvertedTime
     receive_filled_wallets: ReceiveFilledWallets
+    damage_multiplier: DamageMultiplier
     death_link: DeathLink
     link_tunic_color: LinkTunicColor

--- a/worlds/mm_recomp/Options.py
+++ b/worlds/mm_recomp/Options.py
@@ -55,7 +55,7 @@ class ShuffleBossRemains(Choice):
     anything: Any item can be given by any of the Boss Remains, and Boss Remains can be found anywhere in any world.
     bosses: Boss Remains are shuffled amongst themselves as the rewards for defeating bosses."""
     display_name = "Shuffle Boss Remains"
-    option_vanila = 0
+    option_vanilla = 0
     option_anywhere = 1
     option_bosses = 2
     default = 1
@@ -119,6 +119,18 @@ class DamageMultiplier(Choice):
     option_ohko = 4
     default = 1
 
+class DeathBehavior(Choice):
+    """Change what happens when you die.
+    
+    vanilla: The normal death cutscene plays when you die.
+    fast: The death cutscene is massively sped up.
+    moon_crash: Triggers a moon crash and restarts the current cycle."""
+    display_name = "Death Behavior"
+    option_vanilla = 0
+    option_fast = 1
+    option_moon_crash = 2
+    default = 0
+
 
 class LinkTunicColor(OptionList):
     """Choose a color for Link's tunic."""
@@ -145,5 +157,6 @@ class MMROptions(PerGameCommonOptions):
     reset_with_inverted_time: ResetWithInvertedTime
     receive_filled_wallets: ReceiveFilledWallets
     damage_multiplier: DamageMultiplier
+    death_behavior: DeathBehavior
     death_link: DeathLink
     link_tunic_color: LinkTunicColor

--- a/worlds/mm_recomp/__init__.py
+++ b/worlds/mm_recomp/__init__.py
@@ -356,7 +356,7 @@ class MMRWorld(World):
             "starting_heart_locations": 8 if self.options.starting_hearts_are_containers_or_pieces.value == 1 else starting_containers + starting_pieces + shuffled_containers + shuffled_pieces,
             "start_with_consumables": self.options.start_with_consumables.value,
             "permanent_chateau_romani": self.options.permanent_chateau_romani.value,
-            "reset_with_inverted_time": self.options.reset_with_inverted_time.value,
+            "start_with_inverted_time": self.options.start_with_inverted_time.value,
             "receive_filled_wallets": self.options.receive_filled_wallets.value,
             "link_tunic_color": ((self.options.link_tunic_color.value[0] & 0xFF) << 16) | ((self.options.link_tunic_color.value[1] & 0xFF) << 8) | (self.options.link_tunic_color.value[2] & 0xFF)
         }

--- a/worlds/mm_recomp/__init__.py
+++ b/worlds/mm_recomp/__init__.py
@@ -225,6 +225,7 @@ class MMRWorld(World):
         shuffled_pieces = (12 - shp) % 4
         return {
             "skullsanity": self.options.skullsanity.value,
+            "damage_multiplier": self.options.damage_mult.value,
             "death_link": self.options.death_link.value,
             "camc": self.options.camc.value,
             "starting_heart_locations": 8 if self.options.starting_hearts_are_containers_or_pieces.value == 1 else starting_containers + starting_pieces + shuffled_containers + shuffled_pieces,

--- a/worlds/mm_recomp/__init__.py
+++ b/worlds/mm_recomp/__init__.py
@@ -225,7 +225,7 @@ class MMRWorld(World):
         shuffled_pieces = (12 - shp) % 4
         return {
             "skullsanity": self.options.skullsanity.value,
-            "damage_multiplier": self.options.damage_mult.value,
+            "damage_multiplier": self.options.damage_multiplier.value,
             "death_link": self.options.death_link.value,
             "camc": self.options.camc.value,
             "starting_heart_locations": 8 if self.options.starting_hearts_are_containers_or_pieces.value == 1 else starting_containers + starting_pieces + shuffled_containers + shuffled_pieces,

--- a/worlds/mm_recomp/__init__.py
+++ b/worlds/mm_recomp/__init__.py
@@ -113,6 +113,60 @@ class MMRWorld(World):
             locked_item = self.create_item(location_data_table[location_name].locked_item)
             mw.get_location(location_name, player).place_locked_item(locked_item)
 
+        # this is honestly some of the worst code i've ever made, i hate it so much
+        if self.options.shopsanity.value == 0:
+            mw.get_location("Clock Town Trading Post Shop Item 1", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Trading Post Shop Item 2", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Trading Post Shop Item 3", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Trading Post Shop Item 4", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Trading Post Shop Item 5", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Trading Post Shop Item 6", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Trading Post Shop Item 7", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Trading Post Shop Item 8", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Bomb Shop Item 1", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Bomb Shop Item 2", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Clock Town Bomb Shop Item 3", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Bomb Bag Purchase", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Southern Swamp Witch Shop Item 1", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Southern Swamp Witch Shop Item 2", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Southern Swamp Witch Shop Item 3", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Goron Village Shop Item 1", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Goron Village Shop Item 2", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Goron Village Shop Item 3", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Zora Hall Shop 1", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Zora Hall Shop 2", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+            mw.get_location("Zora Hall Shop 3", player).place_locked_item(self.create_item("Deku Nuts (1)"))
+        
+        if self.options.shopsanity.value != 2:
+            mw.get_location("Clock Town Trading Post Shop (Night) Item 1", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Clock Town Trading Post Shop (Night) Item 2", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Clock Town Trading Post Shop (Night) Item 3", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Clock Town Trading Post Shop (Night) Item 4", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Clock Town Trading Post Shop (Night) Item 5", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Clock Town Trading Post Shop (Night) Item 6", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Clock Town Trading Post Shop (Night) Item 7", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Clock Town Trading Post Shop (Night) Item 8", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Goron Village Shop (Spring) Item 1", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Goron Village Shop (Spring) Item 2", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Goron Village Shop (Spring) Item 3", player).place_locked_item(self.create_item("Gold Rupee"))
+            mw.get_location("Goron Village Deku Trade Freestanding HP (Spring)", player).place_locked_item(self.create_item("Gold Rupee"))
+
+        if not self.options.cowsanity:
+            mw.get_location("Termina Log Bombable Grotto Left Cow", player).place_locked_item(self.create_item("Milk"))
+            mw.get_location("Termina Log Bombable Grotto Right Cow", player).place_locked_item(self.create_item("Milk"))
+            mw.get_location("Romani Ranch Barn Free Cow", player).place_locked_item(self.create_item("Milk"))
+            mw.get_location("Romani Ranch Barn Stables Front Cow", player).place_locked_item(self.create_item("Milk"))
+            mw.get_location("Romani Ranch Barn Stables Back Cow", player).place_locked_item(self.create_item("Milk"))
+            mw.get_location("Great Bay Ledge Grotto Left Cow", player).place_locked_item(self.create_item("Milk"))
+            mw.get_location("Great Bay Ledge Grotto Right Cow", player).place_locked_item(self.create_item("Milk"))
+            mw.get_location("Ikana Well Cow", player).place_locked_item(self.create_item("Milk"))
+
+        if not self.options.scrubsanity:
+            mw.get_location("Southern Swamp Deku Scrub Purchase Beans", player).place_locked_item(self.create_item("Deku Nuts (10)"))
+            mw.get_location("Goron Village Deku Scrub Purchase Bomb Bag", player).place_locked_item(self.create_item("Deku Nuts (10)"))
+            mw.get_location("Zora Hall Deku Scrub Purchase Green Potion", player).place_locked_item(self.create_item("Deku Nuts (10)"))
+            mw.get_location("Ikana Canyon Deku Scrub Purchase Blue Potion", player).place_locked_item(self.create_item("Deku Nuts (10)"))
+
         if self.options.shuffle_regional_maps.value == 0:
             mw.get_location("Tingle Clock Town Map Purchase", player).place_locked_item(self.create_item("Clock Town Map"))
             mw.get_location("Tingle Woodfall Map Purchase", player).place_locked_item(self.create_item("Woodfall Map"))
@@ -292,6 +346,9 @@ class MMRWorld(World):
         shuffled_pieces = (12 - shp) % 4
         return {
             "skullsanity": self.options.skullsanity.value,
+            "shopsanity": self.options.shopsanity.value,
+            "scrubsanity": self.options.scrubsanity.value,
+            "cowsanity": self.options.cowsanity.value,
             "damage_multiplier": self.options.damage_multiplier.value,
             "death_behavior": self.options.death_behavior.value,
             "death_link": self.options.death_link.value,

--- a/worlds/mm_recomp/__init__.py
+++ b/worlds/mm_recomp/__init__.py
@@ -226,6 +226,7 @@ class MMRWorld(World):
         return {
             "skullsanity": self.options.skullsanity.value,
             "damage_multiplier": self.options.damage_multiplier.value,
+            "death_behavior": self.options.death_behavior.value,
             "death_link": self.options.death_link.value,
             "camc": self.options.camc.value,
             "starting_heart_locations": 8 if self.options.starting_hearts_are_containers_or_pieces.value == 1 else starting_containers + starting_pieces + shuffled_containers + shuffled_pieces,

--- a/worlds/mm_recomp/__init__.py
+++ b/worlds/mm_recomp/__init__.py
@@ -152,14 +152,14 @@ class MMRWorld(World):
             mw.get_location("Goron Village Deku Trade Freestanding HP (Spring)", player).place_locked_item(self.create_item("Gold Rupee"))
 
         if not self.options.cowsanity:
-            mw.get_location("Termina Log Bombable Grotto Left Cow", player).place_locked_item(self.create_item("Milk"))
-            mw.get_location("Termina Log Bombable Grotto Right Cow", player).place_locked_item(self.create_item("Milk"))
-            mw.get_location("Romani Ranch Barn Free Cow", player).place_locked_item(self.create_item("Milk"))
-            mw.get_location("Romani Ranch Barn Stables Front Cow", player).place_locked_item(self.create_item("Milk"))
-            mw.get_location("Romani Ranch Barn Stables Back Cow", player).place_locked_item(self.create_item("Milk"))
-            mw.get_location("Great Bay Ledge Grotto Left Cow", player).place_locked_item(self.create_item("Milk"))
-            mw.get_location("Great Bay Ledge Grotto Right Cow", player).place_locked_item(self.create_item("Milk"))
-            mw.get_location("Ikana Well Cow", player).place_locked_item(self.create_item("Milk"))
+            mw.get_location("Termina Log Bombable Grotto Left Cow", player).place_locked_item(self.create_item("Bombs (10)"))
+            mw.get_location("Termina Log Bombable Grotto Right Cow", player).place_locked_item(self.create_item("Bombs (10)"))
+            mw.get_location("Romani Ranch Barn Free Cow", player).place_locked_item(self.create_item("Bombs (10)"))
+            mw.get_location("Romani Ranch Barn Stables Front Cow", player).place_locked_item(self.create_item("Bombs (10)"))
+            mw.get_location("Romani Ranch Barn Stables Back Cow", player).place_locked_item(self.create_item("Bombs (10)"))
+            mw.get_location("Great Bay Ledge Grotto Left Cow", player).place_locked_item(self.create_item("Bombs (10)"))
+            mw.get_location("Great Bay Ledge Grotto Right Cow", player).place_locked_item(self.create_item("Bombs (10)"))
+            mw.get_location("Ikana Well Cow", player).place_locked_item(self.create_item("Bombs (10)"))
 
         if not self.options.scrubsanity:
             mw.get_location("Southern Swamp Deku Scrub Purchase Beans", player).place_locked_item(self.create_item("Deku Nuts (10)"))


### PR DESCRIPTION
Adds the following:
- Damage Multipliers
- Death Modifiers
  - `vanilla` doesn't work in-game for now
- Sanity Options
  - ~~**I HATE THIS I HATE THIS I HATE THIS I HATE THIS**~~

Does not add the following:
- Shop logic to prevent merge conflicts with Pixel's/Muervo's changes